### PR TITLE
Added size attribute to entries, method for extracting an entire archive sequentially

### DIFF
--- a/Benchmark/App.config
+++ b/Benchmark/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{49BCF38D-DAF5-42A5-BC77-B36820FB85FA}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Benchmark</RootNamespace>
+    <AssemblyName>Benchmark</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SevenZipExtractor\SevenZipExtractor.csproj">
+      <Project>{8AA97F58-5044-4BBA-B8D9-A74B6947A660}</Project>
+      <Name>SevenZipExtractor</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -4,12 +4,16 @@ using System.IO;
 using System.Linq;
 using System.Diagnostics;
 
-namespace ConsoleApplication87 {
-    class Program {
+namespace ConsoleApplication87 
+{
+    class Program 
+    {
         // you can iterate over the entries in an archive and access their properties
-        static void PrintEntries(ArchiveFile archiveFile) {
+        static void PrintEntries(ArchiveFile archiveFile) 
+        {
             Console.WriteLine("Entries:");
-            foreach (Entry entry in archiveFile.Entries) {
+            foreach (Entry entry in archiveFile.Entries) 
+            {
                 if (entry.IsFolder) continue;
                 Console.WriteLine(string.Format(" {0}", entry.FileName));
                 Console.WriteLine(string.Format("  Size: {0}", entry.Size));
@@ -18,7 +22,8 @@ namespace ConsoleApplication87 {
 
         // if you want to extract only a few entries from the archive
         // use the Entry.Extract method.
-        static void ExtractFirstEntry(ArchiveFile archiveFile) {
+        static void ExtractFirstEntry(ArchiveFile archiveFile) 
+        {
             Entry entry = archiveFile.Entries.First(x => !x.IsFolder);
             Console.WriteLine("Extracting first entry, \"" + entry.FileName + "\"");
             entry.Extract(Path.Combine("extracted", Path.GetFileName(entry.FileName)));
@@ -27,7 +32,8 @@ namespace ConsoleApplication87 {
         // note that extracting the last entry is a lot slower than extracting
         // the first entry because 7-zip has to decompress the archive stream
         // to seek to the last entry
-        static void ExtractLastEntry(ArchiveFile archiveFile) {
+        static void ExtractLastEntry(ArchiveFile archiveFile) 
+        {
             Entry entry = archiveFile.Entries.Last(x => !x.IsFolder);
             Console.WriteLine("Extracting last entry, \"" + entry.FileName + "\"");
             entry.Extract(Path.Combine("extracted", Path.GetFileName(entry.FileName)));
@@ -35,13 +41,15 @@ namespace ConsoleApplication87 {
 
         // if you want to extract all entries from the archive, use ArchiveFile.Extract
         // this is a lot more performant than calling Extract on each entry individually
-        static void ExtractAll(string outputPath, ArchiveFile archiveFile) {
+        static void ExtractAll(string outputPath, ArchiveFile archiveFile) 
+        {
             Console.WriteLine("Extracting all entries to \".\\" + outputPath + "\"");
             archiveFile.Extract(outputPath, true);
         }
 
         // helper function for benchmarking
-        static void Benchmark(Action procedure) {
+        static void Benchmark(Action procedure) 
+        {
             Stopwatch stopwatch = Stopwatch.StartNew();
             procedure();
             stopwatch.Stop();
@@ -49,14 +57,16 @@ namespace ConsoleApplication87 {
             Console.WriteLine("");
         }
 
-        static void Main(string[] args) {
+        static void Main(string[] args) 
+        {
             // provide a path to an archive file here
             string archiveFileName = @"archive.7z";
             string extractTo = Path.Combine("extracted", Path.GetFileNameWithoutExtension(archiveFileName));
             Directory.CreateDirectory("extracted");
 
             // do some things with the archive
-            using (ArchiveFile archiveFile = new ArchiveFile(archiveFileName)) {
+            using (ArchiveFile archiveFile = new ArchiveFile(archiveFileName)) 
+            {
                 Benchmark(() => PrintEntries(archiveFile));
                 Benchmark(() => ExtractFirstEntry(archiveFile));
                 Benchmark(() => ExtractLastEntry(archiveFile));

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using SevenZipExtractor;
+using System.IO;
+using System.Linq;
+using System.Diagnostics;
+
+namespace ConsoleApplication87 {
+    class Program {
+        // you can iterate over the entries in an archive and access their properties
+        static void PrintEntries(ArchiveFile archiveFile) {
+            Console.WriteLine("Entries:");
+            foreach (Entry entry in archiveFile.Entries) {
+                if (entry.IsFolder) continue;
+                Console.WriteLine(string.Format(" {0}", entry.FileName));
+                Console.WriteLine(string.Format("  Size: {0}", entry.Size));
+            }
+        }
+
+        // if you want to extract only a few entries from the archive
+        // use the Entry.Extract method.
+        static void ExtractFirstEntry(ArchiveFile archiveFile) {
+            Entry entry = archiveFile.Entries.First(x => !x.IsFolder);
+            Console.WriteLine("Extracting first entry, \"" + entry.FileName + "\"");
+            entry.Extract(Path.Combine("extracted", Path.GetFileName(entry.FileName)));
+        }
+
+        // note that extracting the last entry is a lot slower than extracting
+        // the first entry because 7-zip has to decompress the archive stream
+        // to seek to the last entry
+        static void ExtractLastEntry(ArchiveFile archiveFile) {
+            Entry entry = archiveFile.Entries.Last(x => !x.IsFolder);
+            Console.WriteLine("Extracting last entry, \"" + entry.FileName + "\"");
+            entry.Extract(Path.Combine("extracted", Path.GetFileName(entry.FileName)));
+        }
+
+        // if you want to extract all entries from the archive, use ArchiveFile.Extract
+        // this is a lot more performant than calling Extract on each entry individually
+        static void ExtractAll(string outputPath, ArchiveFile archiveFile) {
+            Console.WriteLine("Extracting all entries to \".\\" + outputPath + "\"");
+            archiveFile.Extract(outputPath, true);
+        }
+
+        // helper function for benchmarking
+        static void Benchmark(Action procedure) {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            procedure();
+            stopwatch.Stop();
+            Console.WriteLine("Completed in {0} ms", stopwatch.ElapsedMilliseconds);
+            Console.WriteLine("");
+        }
+
+        static void Main(string[] args) {
+            // provide a path to an archive file here
+            string archiveFileName = @"archive.7z";
+            string extractTo = Path.Combine("extracted", Path.GetFileNameWithoutExtension(archiveFileName));
+            Directory.CreateDirectory("extracted");
+
+            // do some things with the archive
+            using (ArchiveFile archiveFile = new ArchiveFile(archiveFileName)) {
+                Benchmark(() => PrintEntries(archiveFile));
+                Benchmark(() => ExtractFirstEntry(archiveFile));
+                Benchmark(() => ExtractLastEntry(archiveFile));
+                Benchmark(() => ExtractAll(extractTo, archiveFile));
+            }
+
+            // we're done
+            Console.WriteLine("Done");
+            Console.ReadKey();
+        }
+    }
+}

--- a/Benchmark/Properties/AssemblyInfo.cs
+++ b/Benchmark/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Benchmark")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Benchmark")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("49bcf38d-daf5-42a5-bc77-b36820fb85fa")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using SevenZipExtractor;
+using System.IO;
 
 namespace ConsoleApplication86
 {
@@ -7,11 +8,17 @@ namespace ConsoleApplication86
     {
         static void Main(string[] args)
         {
-            using (ArchiveFile archiveFile = new ArchiveFile(@"archive.arj"))
+            using (ArchiveFile archiveFile = new ArchiveFile(@"archive.7z"))
             {
                 foreach (Entry entry in archiveFile.Entries)
                 {
+                    if (entry.IsFolder) continue;
                     Console.WriteLine(entry.FileName);
+                    Console.WriteLine(string.Format("  Size: {0}", entry.Size));
+                    string directory = Path.GetDirectoryName(entry.FileName);
+                    if (!string.IsNullOrEmpty(directory)) {
+                        Directory.CreateDirectory(directory);
+                    }
                     entry.Extract(entry.FileName);
                 }
             }

--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -1,77 +1,23 @@
 ﻿using System;
 using SevenZipExtractor;
-using System.IO;
-using System.Linq;
-using System.Diagnostics;
 
 namespace ConsoleApplication86
 {
     class Program
     {
-        // you can iterate over the entries in an archive and access their properties
-        static void PrintEntries(ArchiveFile archiveFile)
-        {
-            Console.WriteLine("Entries:");
-            foreach (Entry entry in archiveFile.Entries)
-            {
-                if (entry.IsFolder) continue;
-                Console.WriteLine(string.Format(" {0}", entry.FileName));
-                Console.WriteLine(string.Format("  Size: {0}", entry.Size));
-            }
-        }
-
-        // if you want to extract only a few entries from the archive
-        // use the Entry.Extract method.
-        static void ExtractFirstEntry(ArchiveFile archiveFile) {
-            Entry entry = archiveFile.Entries.First(x => !x.IsFolder);
-            Console.WriteLine("Extracting first entry, \"" + entry.FileName + "\"");
-            entry.Extract(Path.Combine("extracted", Path.GetFileName(entry.FileName)));
-        }
-
-        // note that extracting the last entry is a lot slower than extracting
-        // the first entry because 7-zip has to decompress the archive stream
-        // to seek to the last entry
-        static void ExtractLastEntry(ArchiveFile archiveFile)
-        {
-            Entry entry = archiveFile.Entries.Last(x => !x.IsFolder);
-            Console.WriteLine("Extracting last entry, \"" + entry.FileName + "\"");
-            entry.Extract(Path.Combine("extracted", Path.GetFileName(entry.FileName)));
-        }
-
-        // if you want to extract all entries from the archive, use ArchiveFile.Extract
-        // this is a lot more performant than calling Extract on each entry individually
-        static void ExtractAll(string outputPath, ArchiveFile archiveFile) {
-            Console.WriteLine("Extracting all entries to \".\\" + outputPath + "\"");
-            archiveFile.Extract(outputPath, true);
-        }
-
-        // helper function for benchmarking
-        static void Benchmark(Action procedure) {
-            Stopwatch stopwatch = Stopwatch.StartNew();
-            procedure();
-            stopwatch.Stop();
-            Console.WriteLine("Completed in {0} ms", stopwatch.ElapsedMilliseconds);
-            Console.WriteLine("");
-        }
-
         static void Main(string[] args)
         {
-            // provide a path to an archive file here
-            string archiveFileName = @"archive.7z";
-            string extractTo = Path.Combine("extracted", Path.GetFileNameWithoutExtension(archiveFileName));
-            Directory.CreateDirectory("extracted");
-
-            // do some things with the archive
-            using (ArchiveFile archiveFile = new ArchiveFile(archiveFileName))
+            using (ArchiveFile archiveFile = new ArchiveFile(@"archive.arj"))
             {
-                Benchmark(() => PrintEntries(archiveFile));
-                Benchmark(() => ExtractFirstEntry(archiveFile));
-                Benchmark(() => ExtractLastEntry(archiveFile));
-                Benchmark(() => ExtractAll(extractTo, archiveFile));
+                foreach (Entry entry in archiveFile.Entries)
+                {
+                    Console.WriteLine(entry.FileName);
+                    entry.Extract(entry.FileName);
+                }
             }
 
-            // we're done
-            Console.WriteLine("Done");
+            Console.WriteLine("");
+            Console.WriteLine("done");
             Console.ReadKey();
         }
     }

--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -8,18 +8,17 @@ namespace ConsoleApplication86
     {
         static void Main(string[] args)
         {
-            using (ArchiveFile archiveFile = new ArchiveFile(@"archive.7z"))
+            string archiveFileName = @"archive.7z";
+            using (ArchiveFile archiveFile = new ArchiveFile(archiveFileName))
             {
                 foreach (Entry entry in archiveFile.Entries)
                 {
                     if (entry.IsFolder) continue;
                     Console.WriteLine(entry.FileName);
                     Console.WriteLine(string.Format("  Size: {0}", entry.Size));
-                    string directory = Path.GetDirectoryName(entry.FileName);
-                    if (!string.IsNullOrEmpty(directory)) {
-                        Directory.CreateDirectory(directory);
-                    }
-                    entry.Extract(entry.FileName);
+                    string outputPath = Path.Combine("extracted", archiveFileName, entry.FileName);
+                    Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
+                    entry.Extract(outputPath);
                 }
             }
 

--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -2,6 +2,7 @@
 using SevenZipExtractor;
 using System.IO;
 using System.Linq;
+using System.Diagnostics;
 
 namespace ConsoleApplication86
 {
@@ -14,26 +15,42 @@ namespace ConsoleApplication86
             foreach (Entry entry in archiveFile.Entries)
             {
                 if (entry.IsFolder) continue;
-                Console.WriteLine(entry.FileName);
+                Console.WriteLine(string.Format(" {0}", entry.FileName));
                 Console.WriteLine(string.Format("  Size: {0}", entry.Size));
             }
-            Console.WriteLine("");
         }
 
         // if you want to extract only a few entries from the archive
         // use the Entry.Extract method.
-        static void ExtractFirstEntry(ArchiveFile archiveFile)
-        {
+        static void ExtractFirstEntry(ArchiveFile archiveFile) {
             Entry entry = archiveFile.Entries.First(x => !x.IsFolder);
-            Console.WriteLine("Extracting " + entry.FileName);
-            entry.Extract(Path.GetFileName(entry.FileName));
-            Console.WriteLine("");
+            Console.WriteLine("Extracting first entry, \"" + entry.FileName + "\"");
+            entry.Extract(Path.Combine("extracted", Path.GetFileName(entry.FileName)));
         }
 
-        // if you want to all entries from the archive, use ArchiveFile.Extract
+        // note that extracting the last entry is a lot slower than extracting
+        // the first entry because 7-zip has to decompress the archive stream
+        // to seek to the last entry
+        static void ExtractLastEntry(ArchiveFile archiveFile)
+        {
+            Entry entry = archiveFile.Entries.Last(x => !x.IsFolder);
+            Console.WriteLine("Extracting last entry, \"" + entry.FileName + "\"");
+            entry.Extract(Path.Combine("extracted", Path.GetFileName(entry.FileName)));
+        }
+
+        // if you want to extract all entries from the archive, use ArchiveFile.Extract
+        // this is a lot more performant than calling Extract on each entry individually
         static void ExtractAll(string outputPath, ArchiveFile archiveFile) {
             Console.WriteLine("Extracting all entries to \".\\" + outputPath + "\"");
             archiveFile.Extract(outputPath, true);
+        }
+
+        // helper function for benchmarking
+        static void Benchmark(Action procedure) {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            procedure();
+            stopwatch.Stop();
+            Console.WriteLine("Completed in {0} ms", stopwatch.ElapsedMilliseconds);
             Console.WriteLine("");
         }
 
@@ -41,13 +58,16 @@ namespace ConsoleApplication86
         {
             // provide a path to an archive file here
             string archiveFileName = @"archive.7z";
+            string extractTo = Path.Combine("extracted", Path.GetFileNameWithoutExtension(archiveFileName));
+            Directory.CreateDirectory("extracted");
 
             // do some things with the archive
             using (ArchiveFile archiveFile = new ArchiveFile(archiveFileName))
             {
-                PrintEntries(archiveFile);
-                ExtractFirstEntry(archiveFile);
-                ExtractAll(Path.GetFileNameWithoutExtension(archiveFileName), archiveFile);
+                Benchmark(() => PrintEntries(archiveFile));
+                Benchmark(() => ExtractFirstEntry(archiveFile));
+                Benchmark(() => ExtractLastEntry(archiveFile));
+                Benchmark(() => ExtractAll(extractTo, archiveFile));
             }
 
             // we're done

--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -1,29 +1,57 @@
 ﻿using System;
 using SevenZipExtractor;
 using System.IO;
+using System.Linq;
 
 namespace ConsoleApplication86
 {
     class Program
     {
+        // you can iterate over the entries in an archive and access their properties
+        static void PrintEntries(ArchiveFile archiveFile)
+        {
+            Console.WriteLine("Entries:");
+            foreach (Entry entry in archiveFile.Entries)
+            {
+                if (entry.IsFolder) continue;
+                Console.WriteLine(entry.FileName);
+                Console.WriteLine(string.Format("  Size: {0}", entry.Size));
+            }
+            Console.WriteLine("");
+        }
+
+        // if you want to extract only a few entries from the archive
+        // use the Entry.Extract method.
+        static void ExtractFirstEntry(ArchiveFile archiveFile)
+        {
+            Entry entry = archiveFile.Entries.First(x => !x.IsFolder);
+            Console.WriteLine("Extracting " + entry.FileName);
+            entry.Extract(Path.GetFileName(entry.FileName));
+            Console.WriteLine("");
+        }
+
+        // if you want to all entries from the archive, use ArchiveFile.Extract
+        static void ExtractAll(string outputPath, ArchiveFile archiveFile) {
+            Console.WriteLine("Extracting all entries to \".\\" + outputPath + "\"");
+            archiveFile.Extract(outputPath, true);
+            Console.WriteLine("");
+        }
+
         static void Main(string[] args)
         {
+            // provide a path to an archive file here
             string archiveFileName = @"archive.7z";
+
+            // do some things with the archive
             using (ArchiveFile archiveFile = new ArchiveFile(archiveFileName))
             {
-                foreach (Entry entry in archiveFile.Entries)
-                {
-                    if (entry.IsFolder) continue;
-                    Console.WriteLine(entry.FileName);
-                    Console.WriteLine(string.Format("  Size: {0}", entry.Size));
-                    string outputPath = Path.Combine("extracted", archiveFileName, entry.FileName);
-                    Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
-                    entry.Extract(outputPath);
-                }
+                PrintEntries(archiveFile);
+                ExtractFirstEntry(archiveFile);
+                ExtractAll(Path.GetFileNameWithoutExtension(archiveFileName), archiveFile);
             }
 
-            Console.WriteLine("");
-            Console.WriteLine("done");
+            // we're done
+            Console.WriteLine("Done");
             Console.ReadKey();
         }
     }

--- a/SevenZipExtractor.sln
+++ b/SevenZipExtractor.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Pack.ps1 = Pack.ps1
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "Benchmark\Benchmark.csproj", "{49BCF38D-DAF5-42A5-BC77-B36820FB85FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{2EFA3756-853D-4282-A528-C644411112F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2EFA3756-853D-4282-A528-C644411112F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2EFA3756-853D-4282-A528-C644411112F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49BCF38D-DAF5-42A5-BC77-B36820FB85FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49BCF38D-DAF5-42A5-BC77-B36820FB85FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49BCF38D-DAF5-42A5-BC77-B36820FB85FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49BCF38D-DAF5-42A5-BC77-B36820FB85FA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SevenZipExtractor/ArchiveFile.cs
+++ b/SevenZipExtractor/ArchiveFile.cs
@@ -87,15 +87,13 @@ namespace SevenZipExtractor
                 {
                     string fileName = this.GetProperty<string>(fileIndex, ItemPropId.kpidPath);
                     bool isFolder = this.GetProperty<bool>(fileIndex, ItemPropId.kpidIsFolder);
-                    uint size = this.GetProperty<int>(fileIndex, ItemPropId.kpidSize);
-                    uint packedSize = this.GetProperty<int>(fileIndex, ItemPropId.kpidPackedSize);
+                    ulong size = this.GetProperty<ulong>(fileIndex, ItemPropId.kpidSize);
 
                     this.entries.Add(new Entry(this.archive, fileIndex)
                     {
                         FileName = fileName,
                         IsFolder = isFolder,
-                        Size = size,
-                        PackedSize = packedSize
+                        Size = size
                     });
                 }
 

--- a/SevenZipExtractor/ArchiveFile.cs
+++ b/SevenZipExtractor/ArchiveFile.cs
@@ -60,6 +60,42 @@ namespace SevenZipExtractor
             this.archiveStream = new InStreamWrapper(archiveStream);
         }
 
+        public void Extract(string outputFolder, bool overwrite) 
+        {
+            IList<Stream> streams = new List<Stream>();
+            for (int i = 0; i < Entries.Count; i++) {
+                Entry entry = entries[i];
+                string fileName = Path.Combine(outputFolder, entry.FileName);
+                if (!entry.IsFolder && (!File.Exists(fileName) || overwrite)) {
+                    Directory.CreateDirectory(Path.GetDirectoryName(fileName));
+                    streams.Add(File.Create(fileName));
+                } else {
+                    streams.Add(null);
+                }
+            }
+            this.archive.Extract(null, 0xFFFFFFFF, 0, new ArchiveStreamCallback(streams));
+            foreach(Stream stream in streams) {
+                if (stream != null) stream.Dispose();
+            }
+        }
+
+        public void Extract(Func<Entry,string> getOutputPath) {
+            IList<Stream> streams = new List<Stream>();
+            foreach (Entry entry in Entries) {
+                string outputPath = getOutputPath(entry);
+                if (!string.IsNullOrEmpty(outputPath)) {
+                    Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
+                    streams.Add(File.Create(outputPath));
+                } else {
+                    streams.Add(null);
+                }
+            }
+            this.archive.Extract(null, 0xFFFFFFFF, 0, new ArchiveStreamCallback(streams));
+            foreach (Stream stream in streams) {
+                if (stream != null) stream.Dispose();
+            }
+        }
+
         public IList<Entry> Entries
         {
             get

--- a/SevenZipExtractor/ArchiveFile.cs
+++ b/SevenZipExtractor/ArchiveFile.cs
@@ -87,11 +87,15 @@ namespace SevenZipExtractor
                 {
                     string fileName = this.GetProperty<string>(fileIndex, ItemPropId.kpidPath);
                     bool isFolder = this.GetProperty<bool>(fileIndex, ItemPropId.kpidIsFolder);
+                    uint size = this.GetProperty<int>(fileIndex, ItemPropId.kpidSize);
+                    uint packedSize = this.GetProperty<int>(fileIndex, ItemPropId.kpidPackedSize);
 
                     this.entries.Add(new Entry(this.archive, fileIndex)
                     {
                         FileName = fileName,
-                        IsFolder = isFolder
+                        IsFolder = isFolder,
+                        Size = size,
+                        PackedSize = packedSize
                     });
                 }
 

--- a/SevenZipExtractor/ArchiveFile.cs
+++ b/SevenZipExtractor/ArchiveFile.cs
@@ -83,7 +83,7 @@ namespace SevenZipExtractor
             IList<Stream> streams = new List<Stream>();
             foreach (Entry entry in Entries) {
                 string outputPath = getOutputPath(entry);
-                if (!string.IsNullOrEmpty(outputPath)) {
+                if (!entry.IsFolder && !string.IsNullOrEmpty(outputPath)) {
                     Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
                     streams.Add(File.Create(outputPath));
                 } else {

--- a/SevenZipExtractor/ArchiveStreamCallback.cs
+++ b/SevenZipExtractor/ArchiveStreamCallback.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 
 namespace SevenZipExtractor
 {
@@ -7,7 +6,6 @@ namespace SevenZipExtractor
     {
         private readonly uint FileNumber;
         private readonly Stream stream;
-        private readonly IList<Stream> streams;
         private OutStreamWrapper FileStream;
 
         public Stream Stream
@@ -24,10 +22,6 @@ namespace SevenZipExtractor
             this.stream = stream;
         }
 
-        public ArchiveStreamCallback(IList<Stream> streams) {
-            this.streams = streams;
-        }
-
         public void SetTotal(ulong total)
         {
         }
@@ -38,19 +32,13 @@ namespace SevenZipExtractor
 
         public int GetStream(uint index, out ISequentialOutStream outStream, AskMode askExtractMode)
         {
-            if (streams != null) {
-                if (streams[(int)index] == null) {
-                    outStream = null;
-                    return 0;
-                }
-                this.FileStream = new OutStreamWrapper(streams[(int) index]);
-                outStream = this.FileStream;
-            }
-            else if ((index == this.FileNumber) && (askExtractMode == AskMode.kExtract)) {
+            if ((index == this.FileNumber) && (askExtractMode == AskMode.kExtract)) 
+            {
                 this.FileStream = new OutStreamWrapper(this.stream);
                 outStream = this.FileStream;
             }
-            else {
+            else 
+            {
                 outStream = null;
             }
 

--- a/SevenZipExtractor/ArchiveStreamCallback.cs
+++ b/SevenZipExtractor/ArchiveStreamCallback.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace SevenZipExtractor
 {
@@ -6,6 +7,7 @@ namespace SevenZipExtractor
     {
         private readonly uint FileNumber;
         private readonly Stream stream;
+        private readonly IList<Stream> streams;
         private OutStreamWrapper FileStream;
 
         public Stream Stream
@@ -22,6 +24,10 @@ namespace SevenZipExtractor
             this.stream = stream;
         }
 
+        public ArchiveStreamCallback(IList<Stream> streams) {
+            this.streams = streams;
+        }
+
         public void SetTotal(ulong total)
         {
         }
@@ -32,13 +38,19 @@ namespace SevenZipExtractor
 
         public int GetStream(uint index, out ISequentialOutStream outStream, AskMode askExtractMode)
         {
-            if ((index == this.FileNumber) && (askExtractMode == AskMode.kExtract))
-            {
+            if (streams != null) {
+                if (streams[(int)index] == null) {
+                    outStream = null;
+                    return 0;
+                }
+                this.FileStream = new OutStreamWrapper(streams[(int) index]);
+                outStream = this.FileStream;
+            }
+            else if ((index == this.FileNumber) && (askExtractMode == AskMode.kExtract)) {
                 this.FileStream = new OutStreamWrapper(this.stream);
                 outStream = this.FileStream;
             }
-            else
-            {
+            else {
                 outStream = null;
             }
 

--- a/SevenZipExtractor/ArchiveStreamsCallback.cs
+++ b/SevenZipExtractor/ArchiveStreamsCallback.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace SevenZipExtractor
+{
+    internal class ArchiveStreamsCallback : IArchiveExtractCallback
+    {
+        private readonly IList<Stream> streams;
+        private OutStreamWrapper FileStream;
+
+        public ArchiveStreamsCallback(IList<Stream> streams) 
+        {
+            this.streams = streams;
+        }
+
+        public void SetTotal(ulong total)
+        {
+        }
+
+        public void SetCompleted(ref ulong completeValue)
+        {
+        }
+
+        public int GetStream(uint index, out ISequentialOutStream outStream, AskMode askExtractMode)
+        {
+            if (streams != null) 
+            {
+                if (streams[(int)index] == null) 
+                {
+                    outStream = null;
+                    return 0;
+                }
+                this.FileStream = new OutStreamWrapper(streams[(int) index]);
+                outStream = this.FileStream;
+            }
+            else 
+            {
+                outStream = null;
+            }
+
+            return 0;
+        }
+
+        public void PrepareOperation(AskMode askExtractMode)
+        {
+        }
+
+        public void SetOperationResult(OperationResult resultEOperationResult)
+        {
+        }
+    }
+}

--- a/SevenZipExtractor/Entry.cs
+++ b/SevenZipExtractor/Entry.cs
@@ -6,21 +6,16 @@ namespace SevenZipExtractor
     {
         private readonly IInArchive archive;
         private readonly uint index;
-        private readonly uint size;
-        private readonly uint packedSize;
 
-        internal Entry(IInArchive archive, uint index, uint size, uint packedSize)
+        internal Entry(IInArchive archive, uint index)
         {
             this.archive = archive;
             this.index = index;
-            this.size = size;
-            this.packedSize = packedSize;
         }
 
         public string FileName { get; internal set; }
         public bool IsFolder { get; internal set; }
-        public uint Size { get; internal set; }
-        public uint PackedSize { get; internal set; }
+        public ulong Size { get; internal set; }
 
         public void Extract(string fileName)
         {

--- a/SevenZipExtractor/SevenZipExtractor.csproj
+++ b/SevenZipExtractor/SevenZipExtractor.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArchiveFileCallback.cs" />
+    <Compile Include="ArchiveStreamsCallback.cs" />
     <Compile Include="ArchiveStreamCallback.cs" />
     <Compile Include="Entry.cs" />
     <Compile Include="Formats.cs" />


### PR DESCRIPTION
The diff is messed up on `ArchiveFile.cs`, [here's an actual diff](https://www.diffchecker.com/xaZghNql).

## Motivation
These changes makes extracting larger archives must faster.  The current approach is inefficient because each time you tell 7-zip to extract a single entry, it must seek to that entry in the archive (decompressing as it seeks).  This results in an `O(n log(n) )` extraction time ignoring overhead.  The extraction time for several archives I was extracting went from >60 seconds to ~3 seconds with these changes.

## Entry changes
I added the `Size` property to entries.  The property is retrieved when the entries are retrieved for a particular archive using `GetProperty<ulong>(fileIndex, ItemPropId.kpidSize)`.  The size property is very useful, and getting it for all of the archive's entries isn't too costly.

## ArchiveFile changes
I extended `ArchiveStreamCallback` with a new constructor that allows us to pass a list of streams to it.  The list of streams maps against the archive's entries.  A potential refactor could be to make this into a `Dictionary<uint,Stream>` instead.

If the streams list is defined, `ArchiveStreamCallback.GetStream` will yield the stream at the index requested by the 7-zip DLL.  If the stream at the index is null we pass null to the 7-zip DLL, which causes it to skip extracting the entry.

The `Archive.Extract` methods wrap the new multi-stream `ArchiveStreamCallback`.

The first `Extract` method takes two arguments: an output folder path and a boolean indicating whether or not to overwrite existing files.  It then extracts all files from the archive to the output folder using `Extract(null, 0xFFFFFFFF, ...)`, preserving the folder structure.

The second `Extract` method takes a `Func<Entry,string>`.  This function is called for each entry in the archive, and is expected to return a file path to extract the entry to.  If the function returns null or an empty string, we skip the file by adding an empty stream.