### PR TITLE
Fixed AccessViolationException on 64 bits

### DIFF
--- a/SevenZipExtractor/ArchiveFile.cs
+++ b/SevenZipExtractor/ArchiveFile.cs
@@ -173,13 +173,12 @@ namespace SevenZipExtractor
         {
             PropVariant propVariant = new PropVariant();
             this.archive.GetProperty(fileIndex, name, ref propVariant);
+            T result = propVariant.VarType != VarEnum.VT_EMPTY
+                ? (T) propVariant.GetObject()
+                : default(T);
+            propVariant.Clear();
 
-            if (propVariant.VarType == VarEnum.VT_EMPTY)
-            {
-                return default(T);
-            }
-            
-            return (T) propVariant.GetObject();
+            return result;
         }
 
         private void InitializeAndValidateLibrary()

--- a/SevenZipExtractor/SevenZipInterface.cs
+++ b/SevenZipExtractor/SevenZipInterface.cs
@@ -1,13 +1,22 @@
 // Version 1.5
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Security.Permissions;
 using System.Threading;
 
 namespace SevenZipExtractor
 {
-    [StructLayout(LayoutKind.Explicit, Size = 16)]
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct PropArray
+    {
+        uint length;
+        IntPtr pointerValues;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
     internal struct PropVariant
     {
         [DllImport("ole32.dll")]
@@ -18,6 +27,7 @@ namespace SevenZipExtractor
         [FieldOffset(8)] public byte byteValue;
         [FieldOffset(8)] public long longValue;
         [FieldOffset(8)] public System.Runtime.InteropServices.ComTypes.FILETIME filetime;
+        [FieldOffset(8)] public PropArray propArray;
 
         public VarEnum VarType
         {


### PR DESCRIPTION
- Fixed PropVariant size to prevent AccessViolationException on 64 bits operating systems; 
- Prevented memory leaks by calling PropVariant.Clear