### PR TITLE
Added further meta data to the Entry class

### DIFF
--- a/SevenZipExtractor/ArchiveFile.cs
+++ b/SevenZipExtractor/ArchiveFile.cs
@@ -67,7 +67,7 @@ namespace SevenZipExtractor
                 }
                 else
                 {
-                    throw new SevenZipException("Unable to guess format autmatically");
+                    throw new SevenZipException("Unable to guess format automatically");
                 }
             }
 
@@ -167,15 +167,32 @@ namespace SevenZipExtractor
                 {
                     string fileName = this.GetProperty<string>(fileIndex, ItemPropId.kpidPath);
                     bool isFolder = this.GetProperty<bool>(fileIndex, ItemPropId.kpidIsFolder);
+                    bool isEncrypted = this.GetProperty<bool>(fileIndex, ItemPropId.kpidEncrypted);
                     ulong size = this.GetProperty<ulong>(fileIndex, ItemPropId.kpidSize);
                     ulong packedSize = this.GetProperty<ulong>(fileIndex, ItemPropId.kpidPackedSize);
+                    DateTime creationTime = this.GetProperty<DateTime>(fileIndex, ItemPropId.kpidCreationTime);
+                    DateTime lastWriteTime = this.GetProperty<DateTime>(fileIndex, ItemPropId.kpidLastWriteTime);
+                    DateTime lastAccessTime = this.GetProperty<DateTime>(fileIndex, ItemPropId.kpidLastAccessTime); 
+                    UInt32 crc = this.GetProperty<UInt32>(fileIndex, ItemPropId.kpidCRC);
+                    UInt32 attributes = this.GetProperty<UInt32>(fileIndex, ItemPropId.kpidAttributes);
+                    string comment = this.GetProperty<string>(fileIndex, ItemPropId.kpidComment);
+                    string hostOS = this.GetProperty<string>(fileIndex, ItemPropId.kpidHostOS);
+                    string method = this.GetProperty<string>(fileIndex, ItemPropId.kpidMethod);
 
                     this.entries.Add(new Entry(this.archive, fileIndex)
                     {
                         FileName = fileName,
                         IsFolder = isFolder,
+                        IsEncrypted = isEncrypted,
                         Size = size,
-                        PackedSize = packedSize
+                        PackedSize = packedSize,
+                        CreationTime = creationTime,
+                        LastWriteTime = lastWriteTime,
+                        CRC = crc,
+                        Attributes = attributes,
+                        Comment = comment,
+                        HostOS = hostOS,
+                        Method = method,
                     });
                 }
 

--- a/SevenZipExtractor/Entry.cs
+++ b/SevenZipExtractor/Entry.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace SevenZipExtractor
 {
@@ -13,7 +14,13 @@ namespace SevenZipExtractor
             this.index = index;
         }
 
+        /// <summary>
+        /// Name of the file with its relative path within the archive
+        /// </summary>
         public string FileName { get; internal set; }
+        /// <summary>
+        /// True if entry is a folder, false if it is a file
+        /// </summary>
         public bool IsFolder { get; internal set; }
         /// <summary>
         /// Original entry size
@@ -23,6 +30,51 @@ namespace SevenZipExtractor
         /// Entry size in a archived state
         /// </summary>
         public ulong PackedSize { get; internal set; }
+
+        /// <summary>
+        /// Date and time of the file (entry) creation
+        /// </summary>
+        public DateTime CreationTime { get; internal set; }
+
+        /// <summary>
+        /// Date and time of the last change of the file (entry)
+        /// </summary>
+        public DateTime LastWriteTime { get; internal set; }
+
+        /// <summary>
+        /// Date and time of the last access of the file (entry)
+        /// </summary>
+        public DateTime LastAccessTime { get; internal set; }
+        
+        /// <summary>
+        /// CRC hash of the entry
+        /// </summary>
+        public UInt32 CRC { get; set; }
+
+        /// <summary>
+        /// Attributes of the entry
+        /// </summary>
+        public UInt32 Attributes { get; set; }
+
+        /// <summary>
+        /// True if entry is encrypted, otherwise false
+        /// </summary>
+        public bool IsEncrypted { get; set; }
+
+        /// <summary>
+        /// Comment of the entry
+        /// </summary>
+        public string Comment { get; set; }
+
+        /// <summary>
+        /// Compression method of the entry
+        /// </summary>
+        public string Method { get; set; }
+
+        /// <summary>
+        /// Host operating system of the entry
+        /// </summary>
+        public string HostOS { get; set; }
 
         public void Extract(string fileName)
         {

--- a/SevenZipExtractor/Entry.cs
+++ b/SevenZipExtractor/Entry.cs
@@ -49,32 +49,32 @@ namespace SevenZipExtractor
         /// <summary>
         /// CRC hash of the entry
         /// </summary>
-        public UInt32 CRC { get; set; }
+        public UInt32 CRC { get; internal set; }
 
         /// <summary>
         /// Attributes of the entry
         /// </summary>
-        public UInt32 Attributes { get; set; }
+        public UInt32 Attributes { get; internal set; }
 
         /// <summary>
         /// True if entry is encrypted, otherwise false
         /// </summary>
-        public bool IsEncrypted { get; set; }
+        public bool IsEncrypted { get; internal set; }
 
         /// <summary>
         /// Comment of the entry
         /// </summary>
-        public string Comment { get; set; }
+        public string Comment { get; internal set; }
 
         /// <summary>
         /// Compression method of the entry
         /// </summary>
-        public string Method { get; set; }
+        public string Method { get; internal set; }
 
         /// <summary>
         /// Host operating system of the entry
         /// </summary>
-        public string HostOS { get; set; }
+        public string HostOS { get; internal set; }
 
         public void Extract(string fileName)
         {


### PR DESCRIPTION
Hi,
I added the most important, additional meta data to the Entry class. This can be useful for instance to compare already existing files with files to extract in a library (e.g. CRC or date comparison.)
The additional properties are according to the available (and usefull) columns in the 7Zip file manager:

* IsEncrypted
* CreationTime
* LastWriteTime
* LastAccessTime
* CRC
* Attributes
* Comment
* HostOS
* Method (Compression)

It should be no a problem to merge. I already tested the output and it looks promising.
What do you think about this change?
Thank you in advance.