### PR TITLE
LZH format, throw InvalidCastException by unbox and implicit cast.

### DIFF
--- a/SevenZipExtractor/ArchiveFile.cs
+++ b/SevenZipExtractor/ArchiveFile.cs
@@ -212,7 +212,7 @@ namespace SevenZipExtractor
             this.archive.GetProperty(fileIndex, name, ref propVariant);
 
             T result = propVariant.VarType != VarEnum.VT_EMPTY
-                ? (T) propVariant.GetObject()
+                ? (T)(dynamic) propVariant.GetObject()
                 : default(T);
 
             propVariant.Clear();


### PR DESCRIPTION
Hello.

LZH(SevenZipFormat.Lzh) format's "GetProperty<ulong>(fileIndex, ItemPropId.kpidSize)" is error.
LZH format's kpidSize is UInt32, so unbox and implicit cast throws InvalidCastException.

(ulong)(object)0U; // error, unbox and implicit cast
(ulong)(dynamic)(object)0U; // success