### PR TITLE
Added callbacks to ArchiveFile.Extract and Entry.Extract for progress events.

### DIFF
--- a/SevenZipExtractor.Tests/Test7Zip.cs
+++ b/SevenZipExtractor.Tests/Test7Zip.cs
@@ -19,5 +19,17 @@ namespace SevenZipExtractor.Tests
         {
             this.TestExtractToStream(Resources.TestFiles.SevenZip, this.TestEntriesWithoutFolder, SevenZipFormat.SevenZip);
         }
+
+        [TestMethod]
+        public void TestProgressWithArchiveExtraction_OK()
+        {
+            this.TestExtractArchiveWithProgress(Resources.TestFiles.SevenZip, SevenZipFormat.SevenZip);
+        }
+        
+        [TestMethod]
+        public void TestProgressWithEntryExtraction_OK()
+        {
+            this.TestExtractEntriesWithProgress(Resources.TestFiles.SevenZip, SevenZipFormat.SevenZip);
+        }
     }
 }

--- a/SevenZipExtractor.Tests/TestArj.cs
+++ b/SevenZipExtractor.Tests/TestArj.cs
@@ -21,5 +21,17 @@ namespace SevenZipExtractor.Tests
 
             this.TestExtractToStream(Resources.TestFiles.ansimate_arj, testEntries, SevenZipFormat.Arj);
         }
+
+        [TestMethod]
+        public void TestProgressWithArchiveExtraction_OK()
+        {
+            this.TestExtractArchiveWithProgress(Resources.TestFiles.ansimate_arj, SevenZipFormat.Arj);
+        }
+        
+        [TestMethod]
+        public void TestProgressWithEntryExtraction_OK()
+        {
+            this.TestExtractEntriesWithProgress(Resources.TestFiles.ansimate_arj, SevenZipFormat.Arj);
+        }
     }
 }

--- a/SevenZipExtractor.Tests/TestBase.cs
+++ b/SevenZipExtractor.Tests/TestBase.cs
@@ -56,7 +56,90 @@ namespace SevenZipExtractor.Tests
                     }
                 }
             }
+        }
 
+        protected void TestExtractEntriesWithProgress(byte[] archiveBytes, SevenZipFormat? sevenZipFormat = null)
+        {
+            MemoryStream memoryStream = new MemoryStream(archiveBytes);
+
+            using (ArchiveFile archiveFile = new ArchiveFile(memoryStream, sevenZipFormat))
+            {
+                foreach (var entry in archiveFile.Entries)
+                {
+                    if (entry.IsFolder)
+                    {
+                        continue;
+                    }
+
+                    using (MemoryStream entryMemoryStream = new MemoryStream())
+                    {
+                        bool progressCalledAtBeginning = false;
+                        bool progressCalledAtEnd = false;
+
+                        entry.Extract(entryMemoryStream, (s, e) =>
+                        {
+                            if (e.CurrentFileTotal > 0)
+                            {
+                                if (e.CurrentFileCompleted == 0)
+                                {
+                                    progressCalledAtBeginning = true;
+                                }
+                                else if (e.CurrentFileCompleted == e.CurrentFileTotal)
+                                {
+                                    progressCalledAtEnd = true;
+                                }
+                            }
+                        });
+
+                        Assert.IsTrue(progressCalledAtBeginning, $"Progress callback was not called at the beginning of extracting file {entry.FileName}.");
+                        Assert.IsTrue(progressCalledAtEnd, $"Progress callback was not called at the end of extracting file {entry.FileName}.");
+                    }
+                }
+            }
+        }
+
+        protected void TestExtractArchiveWithProgress(byte[] archiveBytes, SevenZipFormat? sevenZipFormat = null)
+        {
+            MemoryStream memoryStream = new MemoryStream(archiveBytes);
+
+            string tempPath = Path.Combine(Path.GetTempPath(), "SevenZipExtractorUnitTests");
+            Directory.CreateDirectory(tempPath);
+
+            try
+            {
+                using (ArchiveFile archiveFile = new ArchiveFile(memoryStream, sevenZipFormat))
+                {
+                    int progressCalledAtBeginning = 0;
+                    int progressCalledAtEnd = 0;
+                    HashSet<uint> progressCalledForIndex = new HashSet<uint>();
+
+                    archiveFile.Extract(tempPath, true, (s, e) =>
+                    {
+                        Assert.AreEqual(archiveFile.Entries.Count, e.TotalFileCount, "Incorrect total file count in progress callback.");
+                        progressCalledForIndex.Add(e.CurrentFileNumber);
+
+                        if (e.CurrentFileTotal > 0)
+                        {
+                            if (e.CurrentFileCompleted == 0)
+                            {
+                                progressCalledAtBeginning++;
+                            }
+                            else if (e.CurrentFileCompleted == e.CurrentFileTotal)
+                            {
+                                progressCalledAtEnd++;
+                            }
+                        }
+                    });
+
+                    Assert.AreEqual(archiveFile.Entries.Count, progressCalledForIndex.Count, "Progress callback was not called at all for one or more files.");
+                    Assert.IsTrue(archiveFile.Entries.Count <= progressCalledAtBeginning, "Progress callback was not called at the beginning of extracting each file.");
+                    Assert.IsTrue(progressCalledAtEnd > 0, "Progress callback was not called at the end of extracting files.");
+                }
+            }
+            finally
+            {
+                Directory.Delete(tempPath, true);
+            }
         }
     }
 }

--- a/SevenZipExtractor.Tests/TestLzh.cs
+++ b/SevenZipExtractor.Tests/TestLzh.cs
@@ -21,5 +21,17 @@ namespace SevenZipExtractor.Tests
         {
             this.TestExtractToStream(Resources.TestFiles.lzh, this.TestEntriesWithoutFolder, SevenZipFormat.Lzh);
         }
+        
+        [TestMethod]
+        public void TestProgressWithArchiveExtraction_OK()
+        {
+            this.TestExtractArchiveWithProgress(Resources.TestFiles.lzh, SevenZipFormat.Lzh);
+        }
+        
+        [TestMethod]
+        public void TestProgressWithEntryExtraction_OK()
+        {
+            this.TestExtractEntriesWithProgress(Resources.TestFiles.lzh, SevenZipFormat.Lzh);
+        }
     }
 }

--- a/SevenZipExtractor.Tests/TestRar.cs
+++ b/SevenZipExtractor.Tests/TestRar.cs
@@ -15,6 +15,18 @@ namespace SevenZipExtractor.Tests
         public void TestKnownFormatAndExtractToStream_OK()
         {
             this.TestExtractToStream(Resources.TestFiles.rar, this.TestEntriesWithFolder, SevenZipFormat.Rar5);
+        }        
+        
+        [TestMethod]
+        public void TestProgressWithArchiveExtraction_OK()
+        {
+            this.TestExtractArchiveWithProgress(Resources.TestFiles.rar, SevenZipFormat.Rar5);
+        }
+        
+        [TestMethod]
+        public void TestProgressWithEntryExtraction_OK()
+        {
+            this.TestExtractEntriesWithProgress(Resources.TestFiles.rar, SevenZipFormat.Rar5);
         }
     }
 }

--- a/SevenZipExtractor.Tests/TestZip.cs
+++ b/SevenZipExtractor.Tests/TestZip.cs
@@ -15,6 +15,18 @@ namespace SevenZipExtractor.Tests
         public void TestKnownFormatAndExtractToStream_OK()
         {
             this.TestExtractToStream(Resources.TestFiles.zip, this.TestEntriesWithFolder, SevenZipFormat.Zip);
+        }        
+
+        [TestMethod]
+        public void TestProgressWithArchiveExtraction_OK()
+        {
+            this.TestExtractArchiveWithProgress(Resources.TestFiles.zip, SevenZipFormat.Zip);
+        }
+        
+        [TestMethod]
+        public void TestProgressWithEntryExtraction_OK()
+        {
+            this.TestExtractEntriesWithProgress(Resources.TestFiles.zip, SevenZipFormat.Zip);
         }
     }
 }

--- a/SevenZipExtractor/ArchiveExtractionProgressEventArgs.cs
+++ b/SevenZipExtractor/ArchiveExtractionProgressEventArgs.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SevenZipExtractor
+{
+    public class ArchiveExtractionProgressEventArgs : EntryExtractionProgressEventArgs
+    {
+        /// <summary>
+        /// The index of the file currently being extracted.
+        /// </summary>
+        public uint CurrentFileNumber {get; }
+
+        /// <summary>
+        /// The total number of files that will be extracted.
+        /// </summary>
+        public int TotalFileCount {get; }
+
+        internal ArchiveExtractionProgressEventArgs(uint currentFileNumber, int totalFileCount, ulong currentFileCompleted, ulong currentFileTotal) : base(currentFileCompleted, currentFileTotal)
+        {
+            CurrentFileNumber = currentFileNumber;
+            TotalFileCount = totalFileCount;
+        }
+    }
+}

--- a/SevenZipExtractor/ArchiveExtractionProgressEventArgs.cs
+++ b/SevenZipExtractor/ArchiveExtractionProgressEventArgs.cs
@@ -9,19 +9,19 @@ namespace SevenZipExtractor
     public class ArchiveExtractionProgressEventArgs : EntryExtractionProgressEventArgs
     {
         /// <summary>
-        /// The index of the file currently being extracted.
+        /// The index of the entry currently being extracted.
         /// </summary>
-        public uint CurrentFileNumber {get; }
+        public uint EntryIndex {get; }
 
         /// <summary>
-        /// The total number of files that will be extracted.
+        /// The total number of entries that will be extracted.
         /// </summary>
-        public int TotalFileCount {get; }
+        public int EntryCount {get; }
 
-        internal ArchiveExtractionProgressEventArgs(uint currentFileNumber, int totalFileCount, ulong currentFileCompleted, ulong currentFileTotal) : base(currentFileCompleted, currentFileTotal)
+        internal ArchiveExtractionProgressEventArgs(uint entryIndex, int entryCount, ulong completed, ulong total) : base(completed, total)
         {
-            CurrentFileNumber = currentFileNumber;
-            TotalFileCount = totalFileCount;
+            EntryIndex = entryIndex;
+            EntryCount = entryCount;
         }
     }
 }

--- a/SevenZipExtractor/ArchiveFile.cs
+++ b/SevenZipExtractor/ArchiveFile.cs
@@ -128,7 +128,9 @@ namespace SevenZipExtractor
                     fileStreams.Add(File.Create(outputPath));
                 }
 
-                this.archive.Extract(null, 0xFFFFFFFF, 0, new ArchiveStreamsCallback(fileStreams, progressEventHandler));
+                ArchiveStreamsCallback extractCallback = new ArchiveStreamsCallback(fileStreams, progressEventHandler);
+                this.archive.Extract(null, 0xFFFFFFFF, 0, extractCallback);
+                extractCallback.InvokeFinalProgressCallback();
             }
             finally
             {

--- a/SevenZipExtractor/ArchiveFile.cs
+++ b/SevenZipExtractor/ArchiveFile.cs
@@ -75,7 +75,7 @@ namespace SevenZipExtractor
             this.archiveStream = new InStreamWrapper(archiveStream);
         }
 
-        public void Extract(string outputFolder, bool overwrite = false)
+        public void Extract(string outputFolder, bool overwrite = false, EventHandler<ArchiveExtractionProgressEventArgs> progressEventHandler = null)
         {
             this.Extract(entry =>
             {
@@ -92,10 +92,10 @@ namespace SevenZipExtractor
                 }
 
                 return null;
-            });
+            }, progressEventHandler);
         }
 
-        public void Extract(Func<Entry, string> getOutputPath)
+        public void Extract(Func<Entry, string> getOutputPath, EventHandler<ArchiveExtractionProgressEventArgs> progressEventHandler = null)
         {
             IList<Stream> fileStreams = new List<Stream>();
 
@@ -128,7 +128,7 @@ namespace SevenZipExtractor
                     fileStreams.Add(File.Create(outputPath));
                 }
 
-                this.archive.Extract(null, 0xFFFFFFFF, 0, new ArchiveStreamsCallback(fileStreams));
+                this.archive.Extract(null, 0xFFFFFFFF, 0, new ArchiveStreamsCallback(fileStreams, progressEventHandler));
             }
             finally
             {

--- a/SevenZipExtractor/ArchiveStreamsCallback.cs
+++ b/SevenZipExtractor/ArchiveStreamsCallback.cs
@@ -1,27 +1,50 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace SevenZipExtractor
 {
     internal class ArchiveStreamsCallback : IArchiveExtractCallback
     {
         private readonly IList<Stream> streams;
+        private readonly int streamCount;
+        private readonly EventHandler<ArchiveExtractionProgressEventArgs> progressEventHandler;
 
-        public ArchiveStreamsCallback(IList<Stream> streams) 
+        private uint currentIndex;
+        private ulong currentTotal;
+        private ulong currentCompleteValue;
+
+        public ArchiveStreamsCallback(IList<Stream> streams, EventHandler<ArchiveExtractionProgressEventArgs> progressEventHandler)
         {
             this.streams = streams;
+            this.streamCount = streams.Where(s => s != null).Count();
+            this.progressEventHandler = progressEventHandler;
         }
 
         public void SetTotal(ulong total)
         {
+            this.currentTotal = total;
         }
 
         public void SetCompleted(ref ulong completeValue)
         {
+            this.currentCompleteValue = completeValue;
+
+            // If completeValue is 0, currentIndex has not yet been set correctly, since GetStream is initially called after SetCompleted.
+            if (completeValue > 0)
+            {
+                InvokeProgressCallback();
+            }
         }
 
         public int GetStream(uint index, out ISequentialOutStream outStream, AskMode askExtractMode)
         {
+            this.currentIndex = index;
+
+            // SetTotal and SetCompleted are called before GetStream, so now that currentIndex is correct, we invoke the progress callback.
+            InvokeProgressCallback();
+
             if (askExtractMode != AskMode.kExtract)
             {
                 outStream = null;
@@ -34,7 +57,7 @@ namespace SevenZipExtractor
                 return 0;
             }
 
-            Stream stream = this.streams[(int) index];
+            Stream stream = this.streams[(int)index];
 
             if (stream == null)
             {
@@ -53,6 +76,14 @@ namespace SevenZipExtractor
 
         public void SetOperationResult(OperationResult resultEOperationResult)
         {
+        }
+
+        private void InvokeProgressCallback()
+        {
+            progressEventHandler?.Invoke(
+                this,
+                new ArchiveExtractionProgressEventArgs(this.currentIndex, this.streamCount, this.currentCompleteValue, this.currentTotal)
+            );
         }
     }
 }

--- a/SevenZipExtractor/Entry.cs
+++ b/SevenZipExtractor/Entry.cs
@@ -114,7 +114,9 @@ namespace SevenZipExtractor
 
         public void Extract(Stream stream, EventHandler<EntryExtractionProgressEventArgs> progressEventHandler = null)
         {
-            this.archive.Extract(new[] { this.index }, 1, 0, new ArchiveStreamCallback(this.index, stream, progressEventHandler));
+            ArchiveStreamCallback extractCallback = new ArchiveStreamCallback(this.index, stream, progressEventHandler);
+            this.archive.Extract(new[] { this.index }, 1, 0, extractCallback);
+            extractCallback.InvokeFinalProgressCallback();
         }
     }
 }

--- a/SevenZipExtractor/Entry.cs
+++ b/SevenZipExtractor/Entry.cs
@@ -86,7 +86,7 @@ namespace SevenZipExtractor
         /// </summary>
         public bool IsSplitAfter { get; set; }
 
-        public void Extract(string fileName, bool preserveTimestamp = true)
+        public void Extract(string fileName, bool preserveTimestamp = true, EventHandler<EntryExtractionProgressEventArgs> progressEventHandler = null)
         {
             if (this.IsFolder)
             {
@@ -103,7 +103,7 @@ namespace SevenZipExtractor
 
             using (FileStream fileStream = File.Create(fileName))
             {
-                this.Extract(fileStream);
+                this.Extract(fileStream, progressEventHandler);
             }
 
             if (preserveTimestamp)
@@ -111,9 +111,10 @@ namespace SevenZipExtractor
                 File.SetLastWriteTime(fileName, this.LastWriteTime);
             }
         }
-        public void Extract(Stream stream)
+
+        public void Extract(Stream stream, EventHandler<EntryExtractionProgressEventArgs> progressEventHandler = null)
         {
-            this.archive.Extract(new[] { this.index }, 1, 0, new ArchiveStreamCallback(this.index, stream));
+            this.archive.Extract(new[] { this.index }, 1, 0, new ArchiveStreamCallback(this.index, stream, progressEventHandler));
         }
     }
 }

--- a/SevenZipExtractor/EntryExtractionProgressEventArgs.cs
+++ b/SevenZipExtractor/EntryExtractionProgressEventArgs.cs
@@ -5,19 +5,19 @@ namespace SevenZipExtractor
     public class EntryExtractionProgressEventArgs : EventArgs
     {
         /// <summary>
-        /// Number of bytes completed for file currently being extracted.
+        /// Number of bytes completed. Can be packed or unpacked size depending on format.
         /// </summary>
-        public ulong CurrentFileCompleted { get; }
+        public ulong Completed { get; }
 
         /// <summary>
-        /// The total number of bytes to extract for the current file.
+        /// The total number of bytes to extract. Not set for some formats.
         /// </summary>
-        public ulong CurrentFileTotal { get; }
+        public ulong Total { get; }
 
-        internal EntryExtractionProgressEventArgs(ulong currentFileCompleted, ulong currentFileTotal)
+        internal EntryExtractionProgressEventArgs(ulong completed, ulong total)
         {
-            CurrentFileCompleted = currentFileCompleted;
-            CurrentFileTotal = currentFileTotal;
+            Completed = completed;
+            Total = total;
         }
     }
 }

--- a/SevenZipExtractor/EntryExtractionProgressEventArgs.cs
+++ b/SevenZipExtractor/EntryExtractionProgressEventArgs.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace SevenZipExtractor
+{
+    public class EntryExtractionProgressEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Number of bytes completed for file currently being extracted.
+        /// </summary>
+        public ulong CurrentFileCompleted { get; }
+
+        /// <summary>
+        /// The total number of bytes to extract for the current file.
+        /// </summary>
+        public ulong CurrentFileTotal { get; }
+
+        internal EntryExtractionProgressEventArgs(ulong currentFileCompleted, ulong currentFileTotal)
+        {
+            CurrentFileCompleted = currentFileCompleted;
+            CurrentFileTotal = currentFileTotal;
+        }
+    }
+}


### PR DESCRIPTION
The IArchiveExtractCallback contains SetTotal and SetCompleted which are called at various points during file extraction. These points differ between file formats, but along with GetStream some form of progress reporting is possible, which is what this commit introduces.

The Extract methods on ArchiveFile and Entry now accept an event handler that will be called with the new ArchiveExtractionProgressEventArgs and EntryExtractionProgressEventArgs, respectively, as the extraction progresses. Please note that it is very inconsistent when this is invoked, depending on the format. However, it is guaranteed to be called at least at the beginning and end of extracting each file.